### PR TITLE
profiles: add CFLAGS to prevent the Spectre v2

### DIFF
--- a/profiles/arch/amd64/make.defaults
+++ b/profiles/arch/amd64/make.defaults
@@ -5,7 +5,7 @@ ARCH="amd64"
 ACCEPT_KEYWORDS="${ARCH}"
 
 CHOST="x86_64-pc-linux-gnu"
-CFLAGS="-O2 -pipe"
+CFLAGS="-O2 -pipe -mindirect-branch=thunk -mindirect-branch-register"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
 FCFLAGS="${CFLAGS}"


### PR DESCRIPTION
To be able to prevent the Spectre v2, we should add the following CFLAGS `-mindirect-branch=thunk` and `-mindirect-branch-register` for the general profile.

This PR has to be tested together with https://github.com/flatcar-linux/coreos-overlay/pull/17.

See also:
https://security.googleblog.com/2018/01/more-details-about-mitigations-for-cpu_4.html
https://groups.google.com/forum/#!topic/linux.gentoo.user/6xUuPccmxtU