### PR TITLE
.github: add Github actions for virtual/rust

### DIFF
--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+git fetch origin
+git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+
+pushd "virtual/rust" >/dev/null || exit
+VERSION_OLD=$(ls -1 rust-*.ebuild | sed -n "s/rust-\(1.[0-9]*.[0-9]*\).ebuild/\1/p" | sort -ruV | head -n1)
+git mv rust-${VERSION_OLD}.ebuild "rust-${VERSION_NEW}.ebuild"
+popd >/dev/null || exit
+
+echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"

--- a/.github/workflows/rust-pull-request-alpha.yml
+++ b/.github/workflows/rust-pull-request-alpha.yml
@@ -1,0 +1,37 @@
+on:
+  repository_dispatch:
+    types: [cargo-pull-request-alpha]
+
+jobs:
+  flatcar-rust-prs:
+    runs-on: ubuntu-latest
+    env:
+      GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch latest Cargo release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/rust-lang/rust
+          versionAlpha=$(git -C rust ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/1.[0-9]*.[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
+          rm -rf rust
+          echo ::set-output name=VERSION_ALPHA::$(echo ${versionAlpha})
+          echo ::set-output name=BASE_BRANCH_ALPHA::flatcar-master-alpha
+      - name: Apply patch for Alpha
+        id: apply-patch-alpha
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+        run: .github/workflows/rust-apply-patch.sh
+      - name: Create pull request for Alpha
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_ALPHA }}
+          branch: rust-${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}-alpha
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Cargo in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          commit-message: Upgrade Cargo in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          body: Upgrade Cargo in Alpha from ${{ steps.apply-patch-alpha.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_ALPHA }}
+          labels: alpha

--- a/.github/workflows/rust-pull-request-edge.yml
+++ b/.github/workflows/rust-pull-request-edge.yml
@@ -1,0 +1,37 @@
+on:
+  repository_dispatch:
+    types: [cargo-pull-request-edge]
+
+jobs:
+  flatcar-rust-prs:
+    runs-on: ubuntu-latest
+    env:
+      GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch latest Cargo release
+        id: fetch-latest-release
+        run: |
+          git clone --depth=1 --no-checkout https://github.com/rust-lang/rust
+          versionEdge=$(git -C rust ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/1.[0-9]*.[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
+          rm -rf rust
+          echo ::set-output name=VERSION_EDGE::$(echo ${versionEdge})
+          echo ::set-output name=BASE_BRANCH_EDGE::flatcar-master-edge
+      - name: Apply patch for Edge
+        id: apply-patch-edge
+        env:
+          BASE_BRANCH: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+        run: .github/workflows/rust-apply-patch.sh
+      - name: Create pull request for Edge
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_EDGE }}
+          branch: rust-${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}-edge
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade Cargo in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          commit-message: Upgrade Cargo in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          body: Upgrade Cargo in Edge from ${{ steps.apply-patch-edge.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_EDGE }}
+          labels: edge


### PR DESCRIPTION
Whenever a new upstream Rust release appears, a Github workflow in `coreos-overlay` creates a new pull request for `dev-lang/rust`. At the same time, it sends a repository dispatch event to portage-stable, so it also creates a pull request for `virtual/rust`.

This PR should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/216 https://github.com/flatcar-linux/portage-stable/pull/44 https://github.com/flatcar-linux/portage-stable/pull/45.