### PR TITLE
eclass: clean up .crates2.json when running cargo install

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -134,7 +134,8 @@ cargo_src_install() {
 
 	cargo install -j $(makeopts_jobs) --root="${D}/usr" $(usex debug --debug "") "$@" \
 		|| die "cargo install failed"
-	rm -f "${D}/usr/.crates.toml"
+	rm -f "${ED}/usr/.crates.toml"
+	rm -f "${ED}/usr/.crates2.json"
 
 	[ -d "${S}/man" ] && doman "${S}/man" || return 0
 }


### PR DESCRIPTION
When instaling rust packages with Rust 1.42, it fails like the following message:

```
 * Detected file collision(s):
 *
 *      /build/amd64-usr/usr/.crates2.json
```

Fix the install function in `cargo.eclass` so it can clean up the garbage json file.