### PR TITLE
Fix typo in bind-tools-9.11.22.ebuild

### DIFF
--- a/net-dns/bind-tools/bind-tools-9.11.22.ebuild
+++ b/net-dns/bind-tools/bind-tools-9.11.22.ebuild
@@ -123,7 +123,7 @@ src_install() {
 	fi
 
 	cd "${S}"/bin/dnssec
-	for tool in dsfromkey importkey keyfromlabel keygen \\
+	for tool in dsfromkey importkey keyfromlabel keygen \
 	  revoke settime signzone verify; do
 		dobin dnssec-"${tool}"
 		doman dnssec-"${tool}".8


### PR DESCRIPTION
The typo has no impact since the newer `bind-tools-9.16.6.ebuild` is used anyway. However it leads to an ugly error message during build:
```
/mnt/host/source/src/third_party/portage-stable/net-dns/bind-tools/bind-tools-9.11.22.ebuild: line 127: syntax error near unexpected token `revoke'
/mnt/host/source/src/third_party/portage-stable/net-dns/bind-tools/bind-tools-9.11.22.ebuild: line 127: `         revoke settime signzone verify; do'
 * ERROR: net-dns/bind-tools-9.11.22::portage-stable failed (depend phase):
 *   error sourcing ebuild
 *
 * Call stack:
 *   ebuild.sh, line 635:  Called die
 * The specific snippet of code:
 *                      source "$EBUILD" || die "error sourcing ebuild"
 *
 * If you need support, post the output of `emerge --info '=net-dns/bind-tools-9.11.22::portage-stable'`,
 * the complete build log and the output of `emerge -pqv '=net-dns/bind-tools-9.11.22::portage-stable'`.
 * Working directory: '/usr/lib64/python2.7/site-packages'
 * S: '/build/amd64-usr/var/tmp/portage/net-dns/bind-tools-9.11.22/work/bind-9.11.22'
```