### PR TITLE
acct-group: add group "render" for udev

### DIFF
--- a/acct-group/render/metadata.xml
+++ b/acct-group/render/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>systemd@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/render/render-0.ebuild
+++ b/acct-group/render/render-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=28


### PR DESCRIPTION
### cherry-pick to: `flatcar-2605`

This is a requirement for flatcar-linux/coreos-overlay#543; please see that PR for description & instructions.

Addresses flatcar-linux/Flatcar#169 in the OS image.