### PR TITLE
.github: Improve body text of PR for virtual/rust

### DIFF
--- a/.github/workflows/rust-pull-request-main.yml
+++ b/.github/workflows/rust-pull-request-main.yml
@@ -1,6 +1,6 @@
 on:
   repository_dispatch:
-    types: [cargo-pull-request-main]
+    types: [rust-pull-request-main]
 
 jobs:
   flatcar-rust-prs:
@@ -9,7 +9,7 @@ jobs:
       GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
     steps:
       - uses: actions/checkout@v2
-      - name: Fetch latest Cargo release
+      - name: Fetch latest virtual Rust release
         id: fetch-latest-release
         run: |
           git clone --depth=1 --no-checkout https://github.com/rust-lang/rust
@@ -31,7 +31,10 @@ jobs:
           branch: rust-${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}-main
           author: Flatcar Buildbot <buildbot@flatcar-linux.org>
           committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
-          title: Upgrade Cargo in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
-          commit-message: Upgrade Cargo in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
-          body: Upgrade Cargo in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          title: Upgrade virtual Rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          commit-message: Upgrade virtual Rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+          body: |
+            Upgrade virtual Rust in main from ${{ steps.apply-patch-main.outputs.VERSION_OLD }} to ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
+
+            This PR should be merged together with a corresponding PR in coreos-overlay for [`dev-lang/rust` ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}](https://github.com/flatcar-linux/coreos-overlay/pull/${{ github.event.client_payload.coreos-overlay-pull-request-number}}).
           labels: main


### PR DESCRIPTION
Improve body text of each PR for `virtual/rust`, by mentioning that it should be merged together with its paired PR in coreos-overlay.

Explicitly name `virtual/rust` instead of `Cargo`, because there is no more ebuild for `cargo`.
Rename the dispatched event-type name to `rust-pull-request-main`, as `cargo` has already disappeared.

Make the repository-dispatch action receive additional client-payload with a field `coreos-overlay-pull-request-number` sent by the corresponding PR in coreos-overlay.
The PR number is then used for adding a link in the body text, for pointing back to the PR in coreos-overlay.

This PR should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/575.