### PR TITLE
acct-{user,group}: import ebuilds for portage 3.0.28

### DIFF
--- a/acct-group/portage/metadata.xml
+++ b/acct-group/portage/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>dev-portage@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/portage/portage-0.ebuild
+++ b/acct-group/portage/portage-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=250

--- a/acct-user/portage/metadata.xml
+++ b/acct-user/portage/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>dev-portage@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/portage/portage-0.ebuild
+++ b/acct-user/portage/portage-0.ebuild
@@ -1,0 +1,12 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+ACCT_USER_ID=250
+ACCT_USER_HOME="/var/lib/portage/home"
+ACCT_USER_GROUPS=( portage )
+
+acct-user_add_deps


### PR DESCRIPTION
Import `acct-user/portage` and `acct-group/portage` needed by `sys-apps/portage` 3.0.28.

This PR should be merged together with https://github.com/kinvolk/coreos-overlay/pull/1254.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4396/cldsv