### PR TITLE
changelog: use date format of YYYY-MM-DD

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,8 +8,8 @@ into the repository.  The changes are essentially divided into 4 categories:
 ## How to add the file
 
 Based on the category the PR falls into create a new file in the respective
-directory with the filename format `DD-MM-YYYY-<few-words-about-the-change>.md`
-(can be generated via: `$(date '+%d-%m-%Y')-<few-words-about-the-change>.md`)
+directory with the filename format `YYYY-MM-DD-<few-words-about-the-change>.md`
+(can be generated via: `$(date '+%Y-%m-%d')-<few-words-about-the-change>.md`)
 
 The contents of the file should describe the changes in an elaborative manner
 (use the past tense for the change/bugfix description to avoid confusion with


### PR DESCRIPTION
If we use date format of `DD-MM-YYYY` in changelog file names, the files will not sorted by date. e.g. `01-12-2021` will come before `25-11-2021`.

Use date format of `YYYY-MM-DD` to make the files sorted by date.
