### PR TITLE
changelog: add changelog for edk2-ovmf 202105

### DIFF
--- a/changelog/security/2021-12-02-edk2-ovmf.md
+++ b/changelog/security/2021-12-02-edk2-ovmf.md
@@ -1,0 +1,4 @@
+- [CVE-2019-14584](https://nvd.nist.gov/vuln/detail/CVE-2019-14584)
+- [CVE-2021-28210](https://nvd.nist.gov/vuln/detail/CVE-2021-28210)
+- [CVE-2021-28211](https://nvd.nist.gov/vuln/detail/CVE-2021-28211)
+- [CVE-2021-28213](https://nvd.nist.gov/vuln/detail/CVE-2021-28213)


### PR DESCRIPTION
Add missing changelog addressed by updating edk2-ovmf to [202105](https://github.com/flatcar-linux/portage-stable/pull/256).

- [CVE-2019-14584](https://nvd.nist.gov/vuln/detail/CVE-2019-14584)
- [CVE-2021-28210](https://nvd.nist.gov/vuln/detail/CVE-2021-28210)
- [CVE-2021-28211](https://nvd.nist.gov/vuln/detail/CVE-2021-28211)
- [CVE-2021-28213](https://nvd.nist.gov/vuln/detail/CVE-2021-28213)