### PR TITLE
eclass/udev: Sync with gentoo

### DIFF
--- a/eclass/udev.eclass
+++ b/eclass/udev.eclass
@@ -1,14 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-
-# Flatcar: this file is modified to still support old EAPIs.
-
-
 # @ECLASS: udev.eclass
 # @MAINTAINER:
 # systemd@gentoo.org
-# @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: Default eclass for determining udev directories.
 # @DESCRIPTION:
 # Default eclass for determining udev directories.
@@ -32,18 +28,17 @@
 # }
 # @CODE
 
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
 if [[ -z ${_UDEV_ECLASS} ]]; then
 _UDEV_ECLASS=1
 
 inherit toolchain-funcs
 
-case ${EAPI:-0} in
-	0|1|2|3|4|5|6|7) ;;
-	*) die "${ECLASS}.eclass API in EAPI ${EAPI} not yet established."
-esac
-
-if [[ ${EAPI:-0} == [0123456] ]]; then
-	RDEPEND=""
+if [[ ${EAPI} == [56] ]]; then
 	DEPEND="virtual/pkgconfig"
 else
 	BDEPEND="virtual/pkgconfig"
@@ -88,8 +83,7 @@ get_udevdir() {
 # @FUNCTION: udev_dorules
 # @USAGE: <rule> [...]
 # @DESCRIPTION:
-# Install udev rule(s). Uses doins, thus it is fatal in EAPI 4
-# and non-fatal in earlier EAPIs.
+# Install udev rule(s). Uses doins, thus it is fatal.
 udev_dorules() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -103,8 +97,7 @@ udev_dorules() {
 # @FUNCTION: udev_newrules
 # @USAGE: <oldname> <newname>
 # @DESCRIPTION:
-# Install udev rule with a new name. Uses newins, thus it is fatal
-# in EAPI 4 and non-fatal in earlier EAPIs.
+# Install udev rule with a new name. Uses newins, thus it is fatal.
 udev_newrules() {
 	debug-print-function ${FUNCNAME} "${@}"
 


### PR DESCRIPTION
It's from gentoo commit 3fc8be35607dc65897279f666c8171b174dd2bf2.

Sync with Gentoo to start supporting EAPI 8, which sys-apps/nvme-cli started using in version 1.16. Because of it, 1.16 is not being picked for build despite being marked as stable. Instead 1.14 is used.

CI: http://localhost:9091/job/os/job/manifest/5081/cldsv/