### PR TITLE
Backport FIPS support for 3185

### DIFF
--- a/changelog/changes/2022-03-22-fips.md
+++ b/changelog/changes/2022-03-22-fips.md
@@ -1,0 +1,1 @@
+- Enabled FIPS mode for cryptsetup ([portage-stable#312](https://github.com/flatcar-linux/portage-stable/pull/312))

--- a/sys-fs/cryptsetup/cryptsetup-2.4.3.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-2.4.3.ebuild
@@ -16,10 +16,10 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x
 CRYPTO_BACKENDS="gcrypt kernel nettle +openssl"
 # we don't support nss since it doesn't allow cryptsetup to be built statically
 # and it's missing ripemd160 support so it can't provide full backward compatibility
-IUSE="${CRYPTO_BACKENDS} +argon2 nls pwquality reencrypt ssh static static-libs test +udev urandom"
+IUSE="${CRYPTO_BACKENDS} +argon2 +fips nls pwquality reencrypt ssh static static-libs test +udev urandom"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="^^ ( ${CRYPTO_BACKENDS//+/} )
-	static? ( !gcrypt !ssh !udev )" # 496612, 832711
+	static? ( !gcrypt !ssh !udev !fips )" # 496612, 832711
 
 LIB_DEPEND="
 	dev-libs/json-c:=[static-libs(+)]
@@ -91,6 +91,7 @@ src_configure() {
 		$(use_enable !urandom dev-random)
 		$(use_enable ssh ssh-token)
 		$(usex argon2 '' '--with-luks2-pbkdf=pbkdf2')
+		$(use_enable fips)
 	)
 	econf "${myeconfargs[@]}"
 }

--- a/sys-fs/cryptsetup/metadata.xml
+++ b/sys-fs/cryptsetup/metadata.xml
@@ -7,6 +7,7 @@
 </maintainer>
 <use>
 	<flag name="argon2">Enable password hashing algorithm from <pkg>app-crypt/argon2</pkg></flag>
+	<flag name="fips">Enable FIPS mode restrictions</flag>
 	<flag name="gcrypt">Use <pkg>dev-libs/libgcrypt</pkg> crypto backend</flag>
 	<flag name="kernel">Use kernel crypto backend (mainly for embedded systems)</flag>
 	<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> crypto backend</flag>


### PR DESCRIPTION
see https://github.com/flatcar-linux/coreos-overlay/pull/1778

## How to use


## Testing done


- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
