### PR TITLE
Backport to flatcar-3227: sec-policy/sssd, sys-libs/liburing: add ARM64 support

### DIFF
--- a/sec-policy/selinux-sssd/selinux-sssd-2.20200818-r2.ebuild
+++ b/sec-policy/selinux-sssd/selinux-sssd-2.20200818-r2.ebuild
@@ -11,5 +11,5 @@ inherit selinux-policy-2
 DESCRIPTION="SELinux policy for sssd"
 
 if [[ ${PV} != 9999* ]] ; then
-	KEYWORDS="amd64 -arm ~arm64 ~mips x86"
+	KEYWORDS="amd64 -arm arm64 ~mips x86"
 fi

--- a/sys-libs/liburing/files/liburing-2.1-gnu_source-musl-cpuset.patch
+++ b/sys-libs/liburing/files/liburing-2.1-gnu_source-musl-cpuset.patch
@@ -1,0 +1,42 @@
+https://github.com/axboe/liburing/commit/c34070e08199491fe9653617364f4aea9b9b22be
+
+From: Sam James <sam@gentoo.org>
+Date: Mon, 14 Mar 2022 14:18:55 +0000
+Subject: [PATCH] liburing.h: define GNU_SOURCE for cpu_set_t
+
+On musl, cpu_set_t is only exposed if GNU_SOURCE is defined. While in
+the liburing build system, this is set (43b7ec8d17888df0debccda27dd58f4d1b90245e),
+it can't be guaranteed that folks including the header externally will set
+that macro.
+
+Noticed while investigating a build failure for glusterfs on a musl
+system:
+```
+configure:17701: checking for liburing.h
+configure:17701: x86_64-gentoo-linux-musl-gcc -c -pipe -march=native -fno-diagnostics-color -O2  conftest.c >&5
+In file included from conftest.c:105:
+/usr/include/liburing.h:162:39: error: unknown type name 'cpu_set_t'
+  162 |                                 const cpu_set_t *mask);
+      |                                       ^~~~~~~~~
+configure:17701: $? = 1
+```
+
+Just like _XOPEN_SOURCE, set if needed.
+
+Bug: https://bugs.gentoo.org/829293
+Bug: https://github.com/axboe/liburing/issues/422
+See: 43b7ec8d17888df0debccda27dd58f4d1b90245e
+Signed-off-by: Sam James <sam@gentoo.org>
+--- a/src/include/liburing.h
++++ b/src/include/liburing.h
+@@ -6,6 +6,10 @@
+ #define _XOPEN_SOURCE 500 /* Required for glibc to expose sigset_t */
+ #endif
+ 
++#ifndef _GNU_SOURCE
++#define _GNU_SOURCE /* Required for musl to expose cpu_set_t */
++#endif
++
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <sys/uio.h>

--- a/sys-libs/liburing/liburing-2.1-r2.ebuild
+++ b/sys-libs/liburing/liburing-2.1-r2.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib-minimal toolchain-funcs
+
+DESCRIPTION="Efficient I/O with io_uring"
+HOMEPAGE="https://github.com/axboe/liburing"
+if [[ "${PV}" == *9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/axboe/liburing.git"
+else
+	SRC_URI="https://git.kernel.dk/cgit/${PN}/snapshot/${P}.tar.bz2"
+	KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+LICENSE="MIT"
+SLOT="0/2" # liburing.so major version
+
+IUSE="static-libs"
+# fsync test hangs forever
+RESTRICT="test"
+
+# At least installed headers need <linux/*>, bug #802516
+DEPEND=">=sys-kernel/linux-headers-5.1"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	# Upstream, bug #816798
+	"${FILESDIR}"/${P}-arm-syscall.patch
+	# Upstream, bug #829293
+	"${FILESDIR}"/${P}-gnu_source-musl-cpuset.patch
+)
+
+src_prepare() {
+	default
+
+	if [[ "${PV}" != *9999 ]] ; then
+		# Make sure pkgconfig files contain the correct version
+		# bug #809095 and #833895
+		sed -i "/^Version:/s@[[:digit:]\.]\+@${PV}@" ${PN}.spec || die
+	fi
+
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	local myconf=(
+		--prefix="${EPREFIX}/usr"
+		--libdir="${EPREFIX}/usr/$(get_libdir)"
+		--libdevdir="${EPREFIX}/usr/$(get_libdir)"
+		--mandir="${EPREFIX}/usr/share/man"
+		--cc="$(tc-getCC)"
+		--cxx="$(tc-getCXX)"
+	)
+	# No autotools configure! "econf" will fail.
+	TMPDIR="${T}" ./configure "${myconf[@]}"
+}
+
+multilib_src_compile() {
+	emake V=1 AR="$(tc-getAR)" RANLIB="$(tc-getRANLIB)"
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	if ! use static-libs ; then
+		find "${ED}" -type f -name "*.a" -delete || die
+	fi
+}
+
+multilib_src_test() {
+	emake V=1 runtests
+}


### PR DESCRIPTION
Back-port / cherry-pick of https://github.com/flatcar-linux/portage-stable/pull/334 to flatcar-3227 for https://github.com/flatcar-linux/Flatcar/issues/775. Required by https://github.com/flatcar-linux/coreos-overlay/pull/1961 - see that PR for "how to use" / "Testing done".

This change bumps liburing-2.1 to upstream -rc2 and ingests a cross compiler fix (https://github.com/gentoo/gentoo/pull/24733).

Also, it removes the mask for ARM64 in sec-policy/selinux-sssd to match
Gentoo upstream.