### PR TITLE
changelog: Update weekly updates entry

### DIFF
--- a/changelog/updates/2023-03-21-weekly-package-updates.md
+++ b/changelog/updates/2023-03-21-weekly-package-updates.md
@@ -1,2 +1,1 @@
-- SDK: pahole ([1.24_p20221024](https://github.com/acmel/dwarves/releases/tag/v1.24))
-- SDK: Python ([3.10.10_p3](https://www.python.org/downloads/release/python-31010/))
+- SDK: pahole ([1.24](https://github.com/acmel/dwarves/releases/tag/v1.24))


### PR DESCRIPTION
Python was still at version 3.10.10, so the entry here is not necessary. The _p3 suffix is not an official new version, but instead a note from Gentoo maintainers about having some extra patches on top of the release.

Also use the official version number for pahole.
